### PR TITLE
Update name of AP metric member to 'reset_state'

### DIFF
--- a/histomics_detect/metrics/average_precision.py
+++ b/histomics_detect/metrics/average_precision.py
@@ -107,7 +107,7 @@ class AveragePrecision(tf.keras.metrics.Metric):
         return ap
 
 
-    def reset_states(self):
+    def reset_state(self):
         """
         Resets the true positive, false positive, and false negative states to zero.
         """


### PR DESCRIPTION
When there are no positive anchors during a training step, calls to _update_objectness_metrics will fail due to a lack of positive examples.

I tried to fix this by bypassing the updating of metrics conditional on the availability of positive anchors in train_step. This fix works inside of train_step, but some external tensorflow code is still invoking the call and triggering the error.

This fix requires additional investigation of what is calling metrics outside of train_step.