### PR TITLE
ENH: Demonstrate WrappedModel class.

### DIFF
--- a/example/wsi_example.ipynb
+++ b/example/wsi_example.ipynb
@@ -609,10 +609,17 @@
     "}\n",
     "\n",
     "# Convert pixel data to uint8\n",
-    "tiles = tiles.map(lambda x, y: (tf.cast(x, tf.uint8), y), **dataset_map_options)\n",
-    "\n",
+    "tiles = tiles.map(lambda x, y: (tf.cast(x, tf.uint8), y), **dataset_map_options)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# Run the model on the tiles\n",
-    "tiles = tiles.map(lambda x, y: (x, model(x, tau=0.5, nms_iou=0.3), y), **dataset_map_options)"
+    "tiles1 = tiles.map(lambda x, y: (x, model(x, tau=0.5, nms_iou=0.3), y), **dataset_map_options)"
    ]
   },
   {
@@ -630,7 +637,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "tiles2 = tiles\n",
+    "tiles2 = tiles1\n",
     "tiles2 = tiles2.map(lambda x, p, y: (x, p, tf.shape(p)[0], y), **dataset_map_options)\n",
     "\n",
     "max_number_detections = -1\n",
@@ -671,6 +678,34 @@
     "\n",
     "# check that outputs are same\n",
     "assert tf.math.reduce_all(tf.math.equal(restored(rgb), model(rgb)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<h2>Wrap the model so that predictions can be done with annotations</h2>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class WrappedModel(tf.keras.Model):\n",
+    "    def __init__(self, model, *args, **kwargs):\n",
+    "        super(WrappedModel, self).__init__(*args, **kwargs)\n",
+    "        self.model = model\n",
+    "\n",
+    "    def call(self, pair, *args, **kwargs):\n",
+    "        return (self.model(pair[0], *args, **kwargs), pair[1])\n",
+    "\n",
+    "wrapped_model = WrappedModel(model, name=\"wrapped_model\")\n",
+    "wrapped_tiles = tiles.map(lambda rgb, annot: ((rgb, annot), None, None), **dataset_map_options)\n",
+    "print(\"Starting wrapped_model.predict\")\n",
+    "wrapped_predict_output = wrapped_model.predict(wrapped_tiles)\n",
+    "print(\"Finished wrapped_model.predict\")"
    ]
   }
  ],


### PR DESCRIPTION
Demonstrating a `WrappedModel` class whereby annotation associated with the rgb pixels of an image will be part of the tensorflow graph execution; the rgb and annotation will not need to be matched / zipped together after the graph execution.  Specifically, it enables the following code.
```python
wrapped_model = WrappedModel(model, name="wrapped_model")
wrapped_tiles = tiles.map(lambda rgb, annot: ((rgb, annot), None, None), **dataset_map_options)
wrapped_predict_output = wrapped_model.predict(wrapped_tiles)
```
In this case `model` and `tiles` are as produced earlier in the Jupyter lab.