### PR TITLE
Update model link and hash

### DIFF
--- a/example/whole_slide_inference.ipynb
+++ b/example/whole_slide_inference.ipynb
@@ -23,7 +23,7 @@
     "# install histomics_stream\n",
     "!apt update\n",
     "!apt install -y python3-openslide openslide-tools\n",
-    "!pip install histomics_stream 'large_image[all]' --find-links https://girder.github.io/large_image_wheels\n",
+    "!pip install histomics_stream 'large_image[openslide,ometiff,openjpeg,bioformats]' --find-links https://girder.github.io/large_image_wheels\n",
     "\n",
     "# add to system path\n",
     "import sys\n",


### PR DESCRIPTION
Replaces model file with compressed version using 2 x 1024 dense layers instead of 2 x 4096 dense layers.