### PR TITLE
ENH: Install testing framework

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -3,6 +3,55 @@ name: Build, test, package
 on: [push,pull_request]
 
 jobs:
+  test-python:
+    runs-on: ubuntu-20.04
+    strategy:
+      max-parallel: 2
+      matrix:
+        python-version: [3.6, 3.7, 3.8, 3.9]
+
+        include:
+          - flake8-python-git-tag: "<4.0.0"
+          - pytest-python-git-tag: "<7.0.0"
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: 'Free up disk space'
+        run: |
+          # Workaround for https://github.com/actions/virtual-environments/issues/709
+          df -h
+          sudo apt-get clean
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+          df -h
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          pip install 'flake8${{ matrix.flake8-python-git-tag }}' 'pytest${{ matrix.pytest-python-git-tag }}'
+
+      - name: Install histomics_detect
+        run: |
+          pip install --use-feature=in-tree-build .
+
+      - name: Lint with flake8
+        run: |
+          # stop the build if there are Python syntax errors or undefined names
+          # flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+          # flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+
+      - name: Test with pytest
+        run: |
+          cd test
+          pytest
+        shell: bash
+
   build-n-publish:
     name: Build and publish Python 🐍 distributions 📦 to PyPI
     runs-on: ubuntu-20.04

--- a/test/test_load_histomics_detect.py
+++ b/test/test_load_histomics_detect.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+
+# Copyright NumFOCUS
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def test_histomics_detect_can_be_found():
+    """
+    Purpose: Try "import histomics_detect"
+    """
+
+    import histomics_detect
+
+    print(f"histomics_detect.__version__ = {histomics_detect.__version__}")


### PR DESCRIPTION
This pull request sets up `pytest` for automated testing on GitHub.  Testing now checks that the package builds on Python 3.6, 3.7, 3.8, and 3.9.  The pull request also provides the first execution test, which merely imports `histomics_detect` and prints its `__version__` string.

Setting up of `flake8` for code linting is part of this pull request.  However `flake8` is not actually run because the repository code does not currently comply with its standards.