### PR TITLE
COMP: Replace `tensorflow-gpu` (deprecated) with `tensorflow`

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -11,8 +11,8 @@ jobs:
         python-version: [3.6, 3.7, 3.8, 3.9]
 
         include:
-          - flake8-python-git-tag: "<4.0.0"
-          - pytest-python-git-tag: "<7.0.0"
+          - flake8-python-git-tag: ""
+          - pytest-python-git-tag: ""
 
     steps:
       - uses: actions/checkout@v2
@@ -37,7 +37,7 @@ jobs:
 
       - name: Install histomics_detect
         run: |
-          pip install --use-feature=in-tree-build .
+          pip install .
 
       - name: Lint with flake8
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "pooch",
     "pyyaml",
     "scipy",
-    "tensorflow-gpu>=2.4",
+    "tensorflow>=2.4",
 ]
 dynamic = ["version", "description"]
 


### PR DESCRIPTION
Updates for newer versions of packages.  Specifically,

COMP: Replace `tensorflow-gpu` (deprecated) with `tensorflow`
COMP: `--use-feature=in-tree-build` is no longer supported because now default
COMP: Use current versions of flake8 and pytest